### PR TITLE
Hotfix : `fake-box.com` added to res/throwaway_domains.txt

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -1203,3 +1203,4 @@ zoemail.com
 zoemail.net
 zoemail.org
 zomg.info
+fake-box.com


### PR DESCRIPTION
Please add `fake-box.com` to the disposal emails list. 