### PR TITLE
removed mail.ru from the database

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -589,7 +589,6 @@ mail-filter.com
 mail-temporaire.fr
 mail.by
 mail.mezimages.net
-mail.ru
 mail.zp.ua
 mail114.net
 mail1a.de


### PR DESCRIPTION
Mail.ru is the largest mail service in Russia, it's definitely not a throwaway domain.