### PR TITLE
Removed false positive

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -798,7 +798,6 @@ pfui.ru
 pimpedupmyspace.com
 pjjkp.com
 plexolan.de
-poczta.onet.pl
 politikerclub.de
 pooae.com
 poofy.org


### PR DESCRIPTION
Onet.pl is definitely not disposable mailbox.