### PR TITLE
Don't defer the Laravel provider. Closes #26.

### DIFF
--- a/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
+++ b/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
@@ -23,13 +23,6 @@ use Validator;
 class EmailCheckerServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
-    /**
      * Register the factory in the application container.
      */
     public function register()


### PR DESCRIPTION
Deferring the provider registration means the custom validation rule never gets registered unless the class has already been resolved from the service container.