### PR TITLE
Add support for Laravel 5.5 package auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,16 @@
             "EmailChecker\\Tests\\": "tests/EmailChecker/Tests"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "EmailChecker\\Laravel\\EmailCheckerServiceProvider"
+            ],
+            "aliases": {
+                "EmailChecker": "EmailChecker\\Laravel\\EmailCheckerFacade"
+            }
+        }
+    },
     "scripts": {
         "test": [
             "phpunit --colors=always"


### PR DESCRIPTION
Laravel 5.5 supports package auto-discovery, so editing the `config/app.php` becomes obsolete. 
Here I add the needed configurations to enable Laravel to find this package.

https://laravel.com/docs/5.5/packages#package-discovery