### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.9",
         "knplabs/gaufrette": "^0.1",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
         "symfony/validator": "^2.1"
     },
     "suggest": {

--- a/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
+++ b/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
@@ -53,7 +53,9 @@ class EmailCheckerServiceProvider extends ServiceProvider
         };
 
         Validator::extend(
-            'not_throw_away', $check, 'The :attribute domain is invalid.'
+            'not_throw_away',
+            $check,
+            'The :attribute domain is invalid.'
         );
     }
 

--- a/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
@@ -66,7 +66,9 @@ class AgregatorAdapterTest extends TestCase
      */
     protected function getAdapterMock($isThrowawayDomain, $call = 'any')
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('EmailChecker\Adapter\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adapter->expects($this->$call())
             ->method('isThrowawayDomain')
             ->will($this->returnValue($isThrowawayDomain));

--- a/tests/EmailChecker/Tests/Adpater/FileAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/FileAdapterTest.php
@@ -57,4 +57,13 @@ class FileAdapterTest extends TestCase
             ['comment.ext'],
         ];
     }
+
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorOnInvalidFilePath()
+    {
+        new FileAdapter('invalid_file');
+    }
 }

--- a/tests/EmailChecker/Tests/Constraint/NotThrowawayEmailValidatorTest.php
+++ b/tests/EmailChecker/Tests/Constraint/NotThrowawayEmailValidatorTest.php
@@ -13,15 +13,18 @@ namespace EmailChecker\Tests\Constraint;
 
 use EmailChecker\Constraints\NotThrowawayEmail;
 use EmailChecker\Constraints\NotThrowawayEmailValidator;
+use PHPUnit\Framework\TestCase;
 
-class NotThrowawayEmailValidatorTest extends \PHPUnit_Framework_TestCase
+class NotThrowawayEmailValidatorTest extends TestCase
 {
     protected $context;
     protected $validator;
 
     protected function setUp()
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', [], [], '', false);
+        $this->context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->validator = new NotThrowawayEmailValidator();
         $this->validator->initialize($this->context);
     }

--- a/tests/EmailChecker/Tests/EmailCheckerTest.php
+++ b/tests/EmailChecker/Tests/EmailCheckerTest.php
@@ -17,7 +17,9 @@ class EmailCheckerTest extends TestCase
 {
     public function testEmailIsValid()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('EmailChecker\Adapter\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adapter->expects($this->any())
              ->method('isThrowawayDomain')
              ->will($this->returnValue(false));
@@ -29,7 +31,9 @@ class EmailCheckerTest extends TestCase
 
     public function testEmailIsNotValid()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('EmailChecker\Adapter\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adapter->expects($this->any())
              ->method('isThrowawayDomain')
              ->will($this->returnValue(true));
@@ -41,7 +45,9 @@ class EmailCheckerTest extends TestCase
 
     public function testMalformattedEmail()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('EmailChecker\Adapter\AdapterInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
         $checker = new EmailChecker($adapter);
 
         $this->assertFalse($checker->isValid('foo[at]bar.org'));

--- a/tests/EmailChecker/Tests/TestCase.php
+++ b/tests/EmailChecker/Tests/TestCase.php
@@ -11,7 +11,9 @@
 
 namespace EmailChecker\Tests;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+class TestCase extends PHPUnitTestCase
 {
     protected function getFixtures($file)
     {

--- a/tests/EmailChecker/Tests/ThrowawayDomainsTest.php
+++ b/tests/EmailChecker/Tests/ThrowawayDomainsTest.php
@@ -19,7 +19,8 @@ class ThrowawayDomainsTest extends TestCase
     {
         $domains = new ThrowawayDomains();
 
-        $this->assertTrue(is_array($domains->toArray()));
+        $this->assertInternalType('array', $domains->toArray());
+        $this->assertInstanceOf('\ArrayIterator', $domains->getIterator());
         $this->assertGreaterThan(0, count($domains));
     }
 }


### PR DESCRIPTION
# Changed log
- Add more tests.
- Set the multiple PHPUnit versions to support different PHP versions.
- Using the correct assertions to assert the expected and result values.
- Apply the `phpcbf` fixed by PSER2 coding style.
- The `getMock` is deprecated since PHPUnit `5.7`and disabled in `6.5+`.
Replace the `getMock` with `getMockBuilder` to mock the class instances.