### PR TITLE
Update throwaway_domains.txt

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -1757,7 +1757,6 @@ showslow.de
 shrib.com
 shut.name
 shut.ws
-sibmail.com
 sify.com
 siliwangi.ga
 simpleitsecurity.info


### PR DESCRIPTION
Remove sibmail.com as it is not a disposable mail provider and cannot be used without registration. We have false positives on this domain and we do have many existing users with @sibmail.com domain part.