### PR TITLE
Add domains offered by correotemporal.org

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -2361,3 +2361,5 @@ zumpul.com
 zxcv.com
 zxcvbnm.com
 zzz.com
+klepf.com
+cikuh.com


### PR DESCRIPTION
This domain is offered by https://correotemporal.org/