### PR TITLE
Add compatibility with PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
+    - 8.0
 
 before_install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1.9",
-        "knplabs/gaufrette": ">=0.1,<=0.8",
-        "phpunit/phpunit": "^4.8",
-        "symfony/validator": "^2.1 || ^3.0 || ^4.0"
+        "friendsofphp/php-cs-fixer": "^2.18",
+        "knplabs/gaufrette": "^0.10",
+        "phpunit/phpunit": "^7.5 || ^9.5",
+        "symfony/validator": "^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {
         "symfony/validator": "Add validation constraints",

--- a/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace EmailChecker\Tests\Adpater;
 
+use EmailChecker\Adapter\AdapterInterface;
 use EmailChecker\Adapter\AgregatorAdapter;
 use EmailChecker\Tests\TestCase;
 
@@ -46,11 +47,10 @@ class AgregatorAdapterTest extends TestCase
         $this->assertTrue($this->adapter->isThrowawayDomain('example.org'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCheckArrayValuesInstanceOf()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         new AgregatorAdapter([
             new \stdClass(),
             new \stdClass(),
@@ -66,7 +66,7 @@ class AgregatorAdapterTest extends TestCase
      */
     protected function getAdapterMock($isThrowawayDomain, $call = 'any')
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->$call())
             ->method('isThrowawayDomain')
             ->will($this->returnValue($isThrowawayDomain));

--- a/tests/EmailChecker/Tests/Adpater/ArrayAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/ArrayAdapterTest.php
@@ -23,8 +23,10 @@ class ArrayAdapterTest extends TestCase
 
     protected $adapter;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->adapter = new ArrayAdapter(self::$throawayDomains);
     }
 

--- a/tests/EmailChecker/Tests/Adpater/BuiltInAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/BuiltInAdapterTest.php
@@ -18,8 +18,10 @@ class BuiltInAdapterTest extends TestCase
 {
     protected $adapter;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->adapter = new BuiltInAdapter();
     }
 

--- a/tests/EmailChecker/Tests/Adpater/FileAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/FileAdapterTest.php
@@ -18,8 +18,10 @@ class FileAdapterTest extends TestCase
 {
     protected $adapter;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->adapter = new FileAdapter(__DIR__.'/../../../fixtures/throwaway_domains.txt');
     }
 

--- a/tests/EmailChecker/Tests/Adpater/GaufretteAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/GaufretteAdapterTest.php
@@ -21,8 +21,10 @@ class GaufretteAdapterTest extends TestCase
 {
     protected $adapter;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $filesystem = new Filesystem(new LocalAdapter(__DIR__.'/../../../fixtures'));
         $file = new File('throwaway_domains.txt', $filesystem);
 

--- a/tests/EmailChecker/Tests/Constraint/NotThrowawayEmailValidatorTest.php
+++ b/tests/EmailChecker/Tests/Constraint/NotThrowawayEmailValidatorTest.php
@@ -13,21 +13,28 @@ namespace EmailChecker\Tests\Constraint;
 
 use EmailChecker\Constraints\NotThrowawayEmail;
 use EmailChecker\Constraints\NotThrowawayEmailValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class NotThrowawayEmailValidatorTest extends \PHPUnit_Framework_TestCase
+class NotThrowawayEmailValidatorTest extends TestCase
 {
     protected $context;
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->context = $this->getMock('Symfony\Component\Validator\Context\ExecutionContextInterface', [], [], '', false);
+        parent::setUp();
+
+        $this->context = $this->createMock(ExecutionContextInterface::class);
         $this->validator = new NotThrowawayEmailValidator();
         $this->validator->initialize($this->context);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->context = null;
         $this->validator = null;
     }
@@ -48,11 +55,10 @@ class NotThrowawayEmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate('', new NotThrowawayEmail());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException(UnexpectedTypeException::class);
+
         $this->validator->validate(new \stdClass(), new NotThrowawayEmail());
     }
 

--- a/tests/EmailChecker/Tests/EmailCheckerTest.php
+++ b/tests/EmailChecker/Tests/EmailCheckerTest.php
@@ -11,13 +11,14 @@
 
 namespace EmailChecker\Tests;
 
+use EmailChecker\Adapter\AdapterInterface;
 use EmailChecker\EmailChecker;
 
 class EmailCheckerTest extends TestCase
 {
     public function testEmailIsValid()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->any())
              ->method('isThrowawayDomain')
              ->will($this->returnValue(false));
@@ -29,7 +30,7 @@ class EmailCheckerTest extends TestCase
 
     public function testEmailIsNotValid()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->any())
              ->method('isThrowawayDomain')
              ->will($this->returnValue(true));
@@ -41,7 +42,7 @@ class EmailCheckerTest extends TestCase
 
     public function testMalformattedEmail()
     {
-        $adapter = $this->getMock('EmailChecker\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $checker = new EmailChecker($adapter);
 
         $this->assertFalse($checker->isValid('foo[at]bar.org'));

--- a/tests/EmailChecker/Tests/TestCase.php
+++ b/tests/EmailChecker/Tests/TestCase.php
@@ -11,7 +11,7 @@
 
 namespace EmailChecker\Tests;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected function getFixtures($file)
     {


### PR DESCRIPTION
This PR will add compatibility with PHP 8.

Unfortunately, I have to drop some supported PHP versions.

PHP 8 is strict about return types which were introduced in PHP 7, so I have to drop support for PHP 5.4-5.6.
`void `return type (now required in PHPUnit) was introduced in PHP 7.1, so I have to drop support for PHP 7.0 