### PR TITLE
Remove naver.com from the throwaway domains

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -1427,7 +1427,6 @@ nakedtruth.biz
 nanonym.ch
 national.shitposting.agency
 nationalgardeningclub.com
-naver.com
 negated.com
 neomailbox.com
 nepwk.com


### PR DESCRIPTION
According to wiki and other resources, naver.co is a large South Korean search engine and proper mail provider. Hence it should not be black-listed.