### PR TITLE
Update disponsable domain list

### DIFF
--- a/res/throwaway_domains.txt
+++ b/res/throwaway_domains.txt
@@ -405,8 +405,8 @@ ctos.ch
 cu.cc
 cubiclink.com
 cumallover.me
-curryworld.de
 cuoly.com
+curryworld.de
 cust.in
 cuvox.de
 cylab.org
@@ -1277,6 +1277,11 @@ mailme24.com
 mailmetrash.com
 mailmoat.com
 mailms.com
+mailna.co
+mailna.im
+mailna.in
+mailna.in
+mailna.me
 mailnator.com
 mailnesia.com
 mailnull.com
@@ -1374,6 +1379,7 @@ motique.de
 mountainregionallibrary.net
 mox.pp.ua
 moza.pl
+mozej.com
 mr24.co
 msa.minsmail.com
 msb.minsmail.com
@@ -1621,6 +1627,7 @@ purelogistics.org
 put2.net
 putthisinyourspamdatabase.com
 pwrby.com
+pyjgoingtd.com
 qasti.com
 qc.to
 qibl.at
@@ -1628,7 +1635,6 @@ qipmail.net
 qisdo.com
 qisoa.com
 qoika.com
-qq.com
 qq.my
 qsl.ro
 quadrafit.com
@@ -1720,12 +1726,14 @@ schafmail.de
 schmeissweg.tk
 schrott-email.de
 sd3.in
+seatto.com
 secmail.pw
 secretemail.de
 secure-mail.biz
 secure-mail.cc
 secured-link.net
 securehost.com.es
+seek4wap.com
 seekapps.com
 seekjobs4u.com
 sejaa.lv
@@ -1765,6 +1773,7 @@ showslow.de
 shrib.com
 shut.name
 shut.ws
+sibmail.com
 sify.com
 siliwangi.ga
 simpleitsecurity.info
@@ -2042,6 +2051,7 @@ tlpn.org
 tmail.com
 tmail.ws
 tmailinator.com
+tmpboxnet.me
 tmpjr.me
 toddsbighug.com
 toiea.com
@@ -2135,6 +2145,7 @@ unids.com
 unimark.org
 unit7lahaina.com
 unmail.ru
+uorak.com
 upliftnow.com
 uplipht.com
 uploadnolimit.com
@@ -2194,6 +2205,7 @@ vsimcard.com
 vssms.com
 vubby.com
 vztc.com
+w3boats.com
 w3internet.co.uk
 w9y9640c.com
 wakingupesther.com


### PR DESCRIPTION
Update ths list according to gist.github.com/michenriksen/8710649#.
QQ.com is a domain owned by the Tencent, so it was removed.
Also, some domains were added from sites like temp-mail.org or mohmail.com#.