### PR TITLE
Add missing composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
+        "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "knplabs/gaufrette": "^0.10",
         "phpunit/phpunit": "^7.5 || ^9.5",
         "symfony/validator": "^3.0 || ^4.0 || ^5.0"

--- a/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
+++ b/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
@@ -13,7 +13,7 @@ namespace EmailChecker\Laravel;
 
 use EmailChecker\EmailChecker;
 use Illuminate\Support\ServiceProvider;
-use Validator;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * Laravel service provider.


### PR DESCRIPTION
This PR aim to fix class resolution issues by adding the missing `illuminate/support` composer dependency.

Also, the `Validator` alias was replaced with its facade. Aliases can be replaced or removed in the app configuration, therefore they should never be used in a library.