### PR TITLE
Add compatibility with PHP 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
     - 7.3
     - 7.4
     - 8.0
+    - 8.1
 
 before_install:
     - composer self-update

--- a/src/EmailChecker/ThrowawayDomains.php
+++ b/src/EmailChecker/ThrowawayDomains.php
@@ -30,12 +30,12 @@ class ThrowawayDomains implements \IteratorAggregate, \Countable
         return $this->domains;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->toArray());
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->domains);
     }


### PR DESCRIPTION
This PR is to fix deprecation messages on PHP 8.1:
```
PHP Deprecated:  Return type of EmailChecker\ThrowawayDomains::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /data/src/EmailChecker/ThrowawayDomains.php on line 33

PHP Deprecated:  Return type of EmailChecker\ThrowawayDomains::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /data/src/EmailChecker/ThrowawayDomains.php on line 38
```