### PR TITLE
Solve deprecation for php 8.2

### DIFF
--- a/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
+++ b/src/EmailChecker/Laravel/EmailCheckerServiceProvider.php
@@ -22,6 +22,8 @@ use Illuminate\Support\Facades\Validator;
  */
 class EmailCheckerServiceProvider extends ServiceProvider
 {
+    protected $app;
+
     /**
      * Register the factory in the application container.
      */

--- a/src/EmailChecker/ThrowawayDomains.php
+++ b/src/EmailChecker/ThrowawayDomains.php
@@ -18,6 +18,8 @@ namespace EmailChecker;
  */
 class ThrowawayDomains implements \IteratorAggregate, \Countable
 {
+    protected $domains;
+
     public function __construct()
     {
         $this->domains = Utilities::parseLines(file_get_contents(


### PR DESCRIPTION
Hi @MattKetmo, I tried to use your library and got deprecations messages like
```
Deprecated: Creation of dynamic property EmailChecker\ThrowawayDomains::$domains is deprecated in mattketmo/email-checker/src/EmailChecker/ThrowawayDomains.php on line 23
```
I look for all the dynamic properties in the code and fixed them in this PR.

If you find time to review/merge/release this, this would be awesome.
Thanks.