### PR TITLE
Fix .gitattributes about tests folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-/test export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .php_cs export-ignore


### PR DESCRIPTION
Hi @MattKetmo,

The gitattributes file was excluding test folder, but this folder is called tests.