### PR TITLE
Allow to use constraint as attribute

### DIFF
--- a/src/EmailChecker/Constraints/NotThrowawayEmail.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmail.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraint;
  * @author Matthieu Moquet <matthieu@moquet.net>
  * @Annotation
  */
+#[\Attribute]
 class NotThrowawayEmail extends Constraint
 {
     public $message = 'The domain associated with this email is not valid.';


### PR DESCRIPTION
Hi @MattKetmo

Symfony constraints can be used as attribute for PHP8
https://symfony.com/blog/new-in-symfony-5-2-constraints-as-php-attributes

This PR allow the same for the EmailChecker constraint.