### PR TITLE
Allow to override message when using attributes

### DIFF
--- a/src/EmailChecker/Constraints/NotThrowawayEmail.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmail.php
@@ -21,4 +21,15 @@ use Symfony\Component\Validator\Constraint;
 class NotThrowawayEmail extends Constraint
 {
     public $message = 'The domain associated with this email is not valid.';
+
+    public function __construct(
+        $options = null,
+        array $groups = null,
+        $payload = null,
+        ?string $message = null
+    ) {
+        parent::__construct($options, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+    }
 }


### PR DESCRIPTION
Hi @MattKetmo 

This allows to write
```
#[NotThrowawayEmail(message: 'user.message.error.invalid_email_domain')]
```
when using the constraint as an attribute.

This is similar to Symfony constraint: https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Validator/Constraints/Email.php#L48