### PR TITLE
Fix php 84 deprecations

### DIFF
--- a/src/EmailChecker/Constraints/NotThrowawayEmail.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmail.php
@@ -24,7 +24,7 @@ class NotThrowawayEmail extends Constraint
 
     public function __construct(
         $options = null,
-        array $groups = null,
+        ?array $groups = null,
         $payload = null,
         ?string $message = null
     ) {

--- a/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
@@ -27,7 +27,7 @@ class NotThrowawayEmailValidator extends ConstraintValidator
     /**
      * @param EmailChecker $emailChecker
      */
-    public function __construct(EmailChecker $emailChecker = null)
+    public function __construct(?EmailChecker $emailChecker = null)
     {
         $this->emailChecker = $emailChecker ?: new EmailChecker();
     }

--- a/src/EmailChecker/EmailChecker.php
+++ b/src/EmailChecker/EmailChecker.php
@@ -27,7 +27,7 @@ class EmailChecker
     /**
      * @param AdapterInterface $adapter Checker adapter
      */
-    public function __construct(AdapterInterface $adapter = null)
+    public function __construct(?AdapterInterface $adapter = null)
     {
         $this->adapter = $adapter ?: new BuiltInAdapter();
     }


### PR DESCRIPTION
Hi @MattKetmo 

This lib has deprecations on php 8.4 like
```
EmailChecker\Constraints\NotThrowawayEmail::__construct(): Implicitly marking parameter $groups as nullable is deprecated, the explicit nullable type must be used instead.
EmailChecker\Constraints\NotThrowawayEmailValidator::__construct(): Implicitly marking parameter $emailChecker as nullable is deprecated, the explicit nullable type must be used instead.
EmailChecker\EmailChecker::__construct(): Implicitly marking parameter $adapter as nullable is deprecated, the explicit nullable type must be used instead.
```