### PR TITLE
Add symfony 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - '7.1'
+                    - '7.2'
+                    - '7.3'
+                    - '7.4'
+                    - '8.0'
+                    - '8.1'
+                    - '8.2'
+                    - '8.3'
+                    - '8.4'
+                    - '8.5'
+
+        name: PHP ${{ matrix.php-version }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  coverage: none
+
+            - name: Install dependencies
+              run: composer install --prefer-dist --no-progress --no-interaction
+
+            - name: Run tests
+              run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,7 @@
 name: CI
 
 on:
-    push:
-        branches:
-            - main
     pull_request:
-        types:
-            - opened
-            - synchronize
-            - reopened
 
 jobs:
     test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
     - 7.4
     - 8.0
     - 8.1
+    - 8.2
+    - 8.3
+    - 8.4
+    - 8.5
 
 before_install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         "php": "^7.1 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.18",
-        "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "friendsofphp/php-cs-fixer": "^3.3",
+        "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "knplabs/gaufrette": "^0.10",
         "phpunit/phpunit": "^7.5 || ^9.5",
-        "symfony/validator": "^3.0 || ^4.0 || ^5.0"
+        "symfony/validator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || 8.0"
     },
     "suggest": {
         "symfony/validator": "Add validation constraints",

--- a/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
@@ -35,7 +35,7 @@ class NotThrowawayEmailValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (null === $value || '' === $value) {
             return;

--- a/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
+++ b/tests/EmailChecker/Tests/Adpater/AgregatorAdapterTest.php
@@ -22,9 +22,9 @@ class AgregatorAdapterTest extends TestCase
         $adapter1 = $this->getAdapterMock(false, 'once');
         $adapter2 = $this->getAdapterMock(false, 'once');
 
-        $this->adapter = new AgregatorAdapter([$adapter1, $adapter2]);
+        $adapter = new AgregatorAdapter([$adapter1, $adapter2]);
 
-        $this->assertFalse($this->adapter->isThrowawayDomain('example.org'));
+        $this->assertFalse($adapter->isThrowawayDomain('example.org'));
     }
 
     public function testFirstInvalid()
@@ -32,9 +32,9 @@ class AgregatorAdapterTest extends TestCase
         $adapter1 = $this->getAdapterMock(true, 'once');
         $adapter2 = $this->getAdapterMock(false, 'never');
 
-        $this->adapter = new AgregatorAdapter([$adapter1, $adapter2]);
+        $adapter = new AgregatorAdapter([$adapter1, $adapter2]);
 
-        $this->assertTrue($this->adapter->isThrowawayDomain('example.org'));
+        $this->assertTrue($adapter->isThrowawayDomain('example.org'));
     }
 
     public function testSecondInvalid()
@@ -42,9 +42,9 @@ class AgregatorAdapterTest extends TestCase
         $adapter1 = $this->getAdapterMock(false, 'once');
         $adapter2 = $this->getAdapterMock(true, 'once');
 
-        $this->adapter = new AgregatorAdapter([$adapter1, $adapter2]);
+        $adapter = new AgregatorAdapter([$adapter1, $adapter2]);
 
-        $this->assertTrue($this->adapter->isThrowawayDomain('example.org'));
+        $this->assertTrue($adapter->isThrowawayDomain('example.org'));
     }
 
     public function testCheckArrayValuesInstanceOf()

--- a/tests/EmailChecker/Tests/UtilitiesTest.php
+++ b/tests/EmailChecker/Tests/UtilitiesTest.php
@@ -35,6 +35,7 @@ class UtilitiesTest extends TestCase
             Utilities::parseEmailAddress($email);
             $this->fail(sprintf('"%s" should not be a valid email', $email));
         } catch (InvalidEmailException $e) {
+            $this->expectNotToPerformAssertions();
             return;
         }
     }


### PR DESCRIPTION
Hi @MattKetmo

I'm trying to add Symfony 8 support for this lib.
I discover the following issues:
- NotThrowawayEmailValidator::validate need the `void` return type to be added (which is kinda a BC break)
- NotThrowawayEmail(['message' => ... ]) is not supported anymore (Symfony deprecated passing option with an array)

So I want you opinion on this:
- How do you want to update the NotThrowawayEmail::options param
	- Should we remove it with a BC break ?
	- Should I make a PR first to deprecate it, then we merge it/release it and then we add the SF 8 support with BC breaks ?
	- Should I add a BC with something like
```
$this->message = $options['message'] ?? $message ?? $this->message;
```

- I saw you still support very old version of SF/PHP, what about removing them ? If you plan a new major (since the `: void` is needed), I could add typehint every where WDYT ?