### PR TITLE
SF8 deprecations solving

### DIFF
--- a/src/EmailChecker/Constraints/NotThrowawayEmail.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmail.php
@@ -27,11 +27,16 @@ class NotThrowawayEmail extends Constraint
     public $message = 'The domain associated with this email is not valid.';
 
     public function __construct(
-        $options = null,
+        array|string|null $message = null,
         ?array $groups = null,
-        $payload = null,
-        ?string $message = null,
+        mixed $payload = null,
     ) {
+        $options = [];
+        if (\is_array($message)) {
+            $options = $message;
+            $message = $options['message'] ?? null;
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;

--- a/src/EmailChecker/Constraints/NotThrowawayEmail.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmail.php
@@ -26,6 +26,9 @@ class NotThrowawayEmail extends Constraint
      */
     public $message = 'The domain associated with this email is not valid.';
 
+    /**
+     * @param array<string, mixed>|string|null $message
+     */
     public function __construct(
         array|string|null $message = null,
         ?array $groups = null,

--- a/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
+++ b/src/EmailChecker/Constraints/NotThrowawayEmailValidator.php
@@ -12,7 +12,6 @@
 namespace EmailChecker\Constraints;
 
 use EmailChecker\EmailChecker;
-use ReturnTypeWillChange;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -34,11 +33,8 @@ class NotThrowawayEmailValidator extends ConstraintValidator
 
     /**
      * @param mixed $value
-     *
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof NotThrowawayEmail) {
             throw new UnexpectedTypeException($constraint, NotThrowawayEmail::class);


### PR DESCRIPTION
Fix Symfony 8 deprecations: add void return type to validate() and update constraint constructor signature